### PR TITLE
Fix spelling error in _sidebar.md

### DIFF
--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -1,5 +1,5 @@
 # Resources
 
 - [Learning resources](learning-resources.md)
-- [Documentation references](doc-references__.md)
+- [Documentation references](doc-references.md)
 - [Past work](past-work.md)


### PR DESCRIPTION
Correct the spelling of the reference 'doc-references__.md' on line 4 by changing it into 'doc-references.md'.  

Closes #2 